### PR TITLE
Add targeted docstrings across automation workflow

### DIFF
--- a/EMADB/app/client/events.py
+++ b/EMADB/app/client/events.py
@@ -30,6 +30,15 @@ class SearchEvents:
     def search_using_webdriver(
         self, drug_list: list[str] | None = None, worker: Worker | None = None
     ) -> None:
+        """
+        Execute the end-to-end scraping pipeline for the provided drug list.
+
+        Keyword arguments:
+            drug_list: Optional custom list of drug identifiers to query.
+            worker: Running worker instance used for interruption signaling.
+        Return value:
+            None
+        """
         # check if files downloaded in the past are still present, then remove them
         # create a dictionary of drug names with their initial letter as key
         file_remover()

--- a/EMADB/app/client/window.py
+++ b/EMADB/app/client/window.py
@@ -34,6 +34,14 @@ from EMADB.app.utils.services.toolkit import WebDriverToolkit
 
 ###############################################################################
 def apply_style(app: QApplication) -> QApplication:
+    """
+    Configure the global Qt stylesheet with the preferred theme tweaks.
+
+    Keyword arguments:
+        app: Active QApplication instance that should receive the theme.
+    Return value:
+        QApplication: The themed application instance for fluent chaining.
+    """
     theme = "dark_yellow"
     extra = {"density_scale": "-1"}
     apply_stylesheet(app, theme=f"{theme}.xml", extra=extra)
@@ -118,6 +126,17 @@ class MainWindow:
     def connect_update_setting(
         self, widget, signal_name, config_key, getter=None
     ) -> None:
+        """
+        Bind a UI widget signal to propagate configuration updates.
+
+        Keyword arguments:
+            widget: The widget emitting changes for the tracked preference.
+            signal_name: Signal attribute name to connect against.
+            config_key: Configuration dictionary key to update.
+            getter: Optional callable used to read the widget value.
+        Return value:
+            None
+        """
         if getter is None:
             if isinstance(widget, (QCheckBox)):
                 getter = widget.isChecked
@@ -134,6 +153,14 @@ class MainWindow:
 
     # -------------------------------------------------------------------------
     def auto_connect_settings(self) -> None:
+        """
+        Register default signal bindings for frequently toggled settings.
+
+        Keyword arguments:
+            None
+        Return value:
+            None
+        """
         connections = [
             ("headless", "toggled", "headless"),
             ("ignore_SSL", "toggled", "ignore_SSL"),
@@ -159,8 +186,19 @@ class MainWindow:
 
     # -------------------------------------------------------------------------
     def start_worker(
-        self, worker: Worker, on_finished : Callable, on_error : Callable, on_interrupted
+        self, worker: Worker, on_finished: Callable, on_error: Callable, on_interrupted
     ) -> None:
+        """
+        Schedule a background worker and attach lifecycle callbacks.
+
+        Keyword arguments:
+            worker: Runnable performing the heavy lifting in a new thread.
+            on_finished: Slot invoked when the job completes successfully.
+            on_error: Slot invoked if the worker raises an exception.
+            on_interrupted: Slot invoked when the worker signals interruption.
+        Return value:
+            None
+        """
         worker.signals.finished.connect(on_finished)
         worker.signals.error.connect(on_error)
         worker.signals.interrupted.connect(on_interrupted)
@@ -249,6 +287,14 @@ class MainWindow:
     # -------------------------------------------------------------------------
     @Slot()
     def search_from_file(self) -> None:
+        """
+        Launch scraping flow using drug names sourced from the default file.
+
+        Keyword arguments:
+            None
+        Return value:
+            None
+        """
         if self.worker_running:
             return
 
@@ -268,6 +314,14 @@ class MainWindow:
     # -------------------------------------------------------------------------
     @Slot()
     def search_from_text(self) -> None:
+        """
+        Launch scraping flow using comma-separated drug names from the UI.
+
+        Keyword arguments:
+            None
+        Return value:
+            None
+        """
         if self.worker_running:
             return
 
@@ -299,6 +353,14 @@ class MainWindow:
     # -------------------------------------------------------------------------
     @Slot()
     def check_webdriver(self) -> None:
+        """
+        Inform the user about the availability and version of ChromeDriver.
+
+        Keyword arguments:
+            None
+        Return value:
+            None
+        """
         if self.webdriver.is_chromedriver_installed():
             version = self.webdriver.check_chrome_version()
             message = f"Chrome driver is installed, current version: {version}"

--- a/EMADB/app/client/workers.py
+++ b/EMADB/app/client/workers.py
@@ -26,7 +26,17 @@ class WorkerSignals(QObject):
 
 ###############################################################################
 class Worker(QRunnable):
-    def __init__(self, fn : Callable[[], None], *args : Any, **kwargs : Any) -> None:
+    def __init__(self, fn: Callable[[], None], *args: Any, **kwargs: Any) -> None:
+        """
+        Prepare a QRunnable with cooperative interruption and progress hooks.
+
+        Keyword arguments:
+            fn: Callable executed on the worker thread.
+            args: Positional arguments forwarded to the callable.
+            kwargs: Keyword arguments forwarded to the callable.
+        Return value:
+            None
+        """
         super().__init__()
         self.fn = fn
         self.args = args
@@ -66,6 +76,14 @@ class Worker(QRunnable):
     # -------------------------------------------------------------------------
     @Slot()
     def run(self) -> None:
+        """
+        Execute the target callable and emit lifecycle signals accordingly.
+
+        Keyword arguments:
+            None
+        Return value:
+            None
+        """
         try:
             # Remove progress_callback if not accepted by the function
             if (

--- a/EMADB/app/utils/services/autopilot.py
+++ b/EMADB/app/utils/services/autopilot.py
@@ -23,6 +23,15 @@ class EMAWebPilot:
 
     # -------------------------------------------------------------------------
     def autoclick(self, string: str, mode: str = "XPATH") -> None:
+        """
+        Locate an element by selector and trigger a click once it is visible.
+
+        Keyword arguments:
+            string: Selector used to find the element on the page.
+            mode: Determines whether the selector is CSS or XPATH based.
+        Return value:
+            None
+        """
         wait = WebDriverWait(self.driver, self.wait_time)
         by_elem = By.CSS_SELECTOR if mode == "CSS" else By.XPATH
         page = wait.until(EC.visibility_of_element_located((by_elem, string)))
@@ -30,6 +39,14 @@ class EMAWebPilot:
 
     # -------------------------------------------------------------------------
     def drug_finder(self, name: str) -> None:
+        """
+        Open a new tab containing the ADR dashboard for the provided drug name.
+
+        Keyword arguments:
+            name: Drug name to locate using the partial link text strategy.
+        Return value:
+            None
+        """
         wait = WebDriverWait(self.driver, self.wait_time)
         item = wait.until(
             EC.visibility_of_element_located((By.PARTIAL_LINK_TEXT, name.upper()))
@@ -47,6 +64,14 @@ class EMAWebPilot:
 
     # -------------------------------------------------------------------------
     def click_and_download(self, current_page: bool = True) -> None:
+        """
+        Export the currently open ADR dashboard to Excel through the UI menu.
+
+        Keyword arguments:
+            current_page: When False, selects the option to export all pages.
+        Return value:
+            None
+        """
         flag = 1 if current_page else 2
         wait = WebDriverWait(self.driver, self.wait_time)
         xpath = '//*[@id="uberBar_dashboardpageoptions_image"]'
@@ -61,6 +86,14 @@ class EMAWebPilot:
 
     # -------------------------------------------------------------------------
     def check_DAP_filenames(self) -> None:
+        """
+        Poll the download directory until the Excel export is completed.
+
+        Keyword arguments:
+            None
+        Return value:
+            None
+        """
         while True:
             current_files = os.listdir(DOWNLOAD_PATH)
             DAP_files = [x for x in current_files if "DAP" in x]
@@ -74,6 +107,15 @@ class EMAWebPilot:
     def download_manager(
         self, grouped_drugs: dict[str, list[str]], **kwargs: Any
     ) -> None:
+        """
+        Iterate over grouped drug names and orchestrate dashboard downloads.
+
+        Keyword arguments:
+            grouped_drugs: Dictionary keyed by initial letter containing drug lists.
+            kwargs: Additional parameters forwarded to worker supervision logic.
+        Return value:
+            None
+        """
         for letter, drugs in grouped_drugs.items():
             self.driver.get(self.data_URL)
             letter_css = f"a[onclick=\"showSubstanceTable('{letter.lower()}')\"]"

--- a/EMADB/app/utils/services/toolkit.py
+++ b/EMADB/app/utils/services/toolkit.py
@@ -34,6 +34,14 @@ class WebDriverToolkit:
 
     # -------------------------------------------------------------------------
     def is_chromedriver_installed(self) -> str:
+        """
+        Validate that a ChromeDriver binary can be instantiated with options.
+
+        Keyword arguments:
+            None
+        Return value:
+            str: Success confirmation or formatted error message.
+        """
         try:
             driver = Chrome(options=self.options)
             driver.quit()
@@ -44,6 +52,14 @@ class WebDriverToolkit:
 
     # -------------------------------------------------------------------------
     def check_chrome_version(self) -> Any | Literal["Version not detected"]:
+        """
+        Retrieve the Chrome browser version reported by WebDriver capabilities.
+
+        Keyword arguments:
+            None
+        Return value:
+            Any | Literal["Version not detected"]: Detected version string or fallback label.
+        """
         try:
             driver = Chrome(options=self.options)
             version = driver.capabilities["browserVersion"]  # type: ignore
@@ -56,6 +72,14 @@ class WebDriverToolkit:
 
     # -------------------------------------------------------------------------
     def initialize_webdriver(self) -> Chrome:
+        """
+        Install ChromeDriver if needed and return a configured WebDriver instance.
+
+        Keyword arguments:
+            None
+        Return value:
+            Chrome: Ready-to-use Selenium WebDriver pointing to Chrome.
+        """
         self.path = ChromeDriverManager().install()
         driver = Chrome(options=self.options)
 


### PR DESCRIPTION
## Summary
- add docstrings that clarify the multi-step scraping pipeline and worker lifecycle
- document the webdriver toolkit helpers and UI worker orchestration entry points
- expand inline guidance around Selenium downloads to describe the control flow

## Testing
- python -m compileall EMADB

------
https://chatgpt.com/codex/tasks/task_e_690396290e64832f8e0a76ee2b4b16e9